### PR TITLE
Specialize elt for arrays and list indices

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1317,11 +1317,23 @@ Methods:
 +
 Returns `(CL:ELT SEQUENCE INDEX)`.
 
-* `ARRAY T`
+* `ARRAY INTEGER`
 +
 Multi-Dimensional Arrays.
 +
 Returns `(ROW-MAJOR-AREF SEQUENCE INDEX)`.
+
+* `ARRAY LIST`
++
+Multi-Dimensional Arrays.
++
+If length of `index` matches array's rank, returns `(apply #'aref sequence
+index)`.
+
+If `index`'s length is less than the array's rank, then returns a displaced
+array whose dimensions are `sequence`'s "unused" dimensions (ie `(nthcdr
+(array-dimensions sequence) (length index))`) and which shares storage with the
+"subarray" of `sequence` specificied by `index`
 
 * `HASH-TABLE T`
 +
@@ -1354,11 +1366,24 @@ Methods:
 +
 Returns `(SETF (CL:ELT SEQUENCE INDEX) VALUE)`.
 
-* `T ARRAY T`
+* `T ARRAY INTEGER`
 +
 Multi-Dimensional Arrays.
 +
 Returns `(SETF (ROW-MAJOR-AREF SEQUENCE INDEX) VALUE)`
+
+* `ARRAY LIST`
++
+Multi-Dimensional Arrays.
++
+If length of `index` matches array's rank, returns `(setf (apply #'aref sequence
+index) value)`.
+
+If `index`'s length is less than the array's rank, then copies the contents of
+`value` to the "subarray" (see `generic-cl:elt`) specified by `index` and then
+returns `(elt sequence index)`. `value`'s dimensions must equal the "unused"
+dimensions of `sequence` (ie `(nthcdr (array-dimensions sequence) (length
+index))`).
 
 * `T HASH-TABLE T`
 +

--- a/test/sequences.lisp
+++ b/test/sequences.lisp
@@ -298,8 +298,19 @@
       (is (setf (elt it 1) 100) 100)
       (is it (alist-hash-map '((0 . 10) (1 . 100) (2 . 30) (3 . 40))) :test #'equalp)))
 
+  (subtest "Test ELT and (SETF ELT) on multidimensional arrays"
+           (alet #3A(((1 0) (0 1)) ((2 3) (4 5)) ((5 6) (7 8)))
+             (is (elt it 0) 1)
+             (is (elt it '(1)) #2A((2 3) (4 5)) :test #'equalp)
+             (setf (elt it '(1 0)) #(200 300))
+             (is (elt it '(1)) #2A((200 300) (4 5)) :test #'equalp)
+             (setf (elt it '(1)) #2A((2000 3000) (4000 5000)))
+             (is (elt it '(1)) #2A((2000 3000) (4000 5000)) :test #'equalp)
+             (setf (elt it nil) #3A(((0 0) (0 0)) ((0 0) (0 0)) ((0 0) (0 0))))
+             (is it #3A(((0 0) (0 0)) ((0 0) (0 0)) ((0 0) (0 0))) :test #'equalp)))
+
   (subtest "Test FIRST"
-    (is (first '(1 2 3 4)) 1)
+           (is (first '(1 2 3 4)) 1)
     (is (first #(a b c d)) 'a)
     (is (first #2A((1 2) (3 4))) 1)
     (is (first (list-wrap 'x 'y 'z)) 'x))


### PR DESCRIPTION
This functionality probably exceeds `generic-cl`'s mission, but I thought I'd submit a PR nonetheless. 

This PR allows `generic-cl:elt` to access contiguous slices (ie displaced arrays) of multidimensional arrays. It's easiest to explain this by example

```
(defvar a #2A((0 1) (2 3)))
(elt a '(0))
;; => #(0 1)
(elt a '(1))
;; => #(2 3)
(setf (elt a '(1)) #(200 300))
;; => #(200 300)
a
;; => #2A((0 1) (200 300))
(defvar b (elt a '(0)))
(setf (elt b '(0)) -100)
a
=> #2A((-100 1) (200 300))
```

The current `elt` for `arrays` only accepts integers (implicitly anyways, since `row-major-aref` will fail on anything else). I've changed the old `elt` type specs from `(array t) ` to `(array integer)`, and the newfangled behavior is specialized on `(array list)`. Therefore no existing code should be affected

Notes

This implementation is probably slow (though as fast as it can be, I think). There are two reasons

1. There's no place to cache per-dimension word sizes for the arrays (would love to be proven wrong here), so both `setf` and `elt` have recompute on those every call.

2. The `setf` operation copies the`value` array index-by-index rather than as a block. I don't think CL has any efficient functions for that though