### PR TITLE
Drop complex number methods

### DIFF
--- a/doc/arithmetic.adoc
+++ b/doc/arithmetic.adoc
@@ -200,7 +200,7 @@ Returns true if `A` is less than zero.
 
 .Methods
 
-* `NUMBER`
+* `REAL`
 +
 Returns `(CL:MINUSP A)`.
 
@@ -222,7 +222,7 @@ Returns true if `A` is greater than zero.
 
 .Methods
 
-* `NUMBER`
+* `REPL`
 +
 Returns `(CL:PLUSP A)`.
 
@@ -310,7 +310,7 @@ Returns true if `A` is even.
 
 .Methods
 
-* `NUMBER`
+* `INTEGER`
 +
 Returns `(CL:EVENP A)`
 
@@ -327,7 +327,7 @@ Returns true if `A` is odd.
 
 .Methods
 
-* `NUMBER`
+* `INTEGER`
 +
 Returns `(CL:ODDP A)`
 
@@ -347,7 +347,7 @@ value.
 
 .Methods
 
-* `NUMBER`
+* `REAL`
 +
 Returns `(CL:FLOOR N D)` if `D` is provided otherwise returns
 `(CL:FLOOR N)`.
@@ -363,7 +363,7 @@ the first value, and the `N - result * D` as the second return value.
 
 .Methods
 
-* `NUMBER`
+* `REAL`
 +
 Returns `(CL:CEILING N D)` if `D` is provided otherwise returns
 `(CL:CEILING N)`.
@@ -379,7 +379,7 @@ value, and the remainder `N - result * D` as the second return value.
 
 .Methods
 
-* `NUMBER`
+* `REAL`
 +
 Returns `(CL:TRUNCATE N D)` if `D` is provided otherwise returns
 `(CL:TRUNCATE N)`.
@@ -399,7 +399,7 @@ to the nearest even integer.
 
 .Methods
 
-* `NUMBER`
+* `REAL`
 +
 Returns `(CL:ROUND N D)` if `D` is provided otherwise returns
 `(CL:ROUND N)`.
@@ -413,7 +413,7 @@ Returns the remainder of the <<FLOOR>> operation on `N` and `D`.
 
 .Methods
 
-* `NUMBER`
+* `REAL`
 +
 Returns `(CL:MOD N D)`.
 
@@ -430,7 +430,7 @@ Returns the remainder of the <<TRUNCATE>> operation on `N` and `D`.
 
 .Methods
 
-* `NUMBER`
+* `REAL`
 +
 Returns `(CL:REM N D)`.
 

--- a/doc/comparison.adoc
+++ b/doc/comparison.adoc
@@ -29,7 +29,7 @@ Generic Function: `EQUALP A B`
 Returns true if object `A` is equal to object `B`.
 
 .Methods
-* `NUMBER NUMBER`
+* `REAL REAL`
 +
 Returns true if `A` and `B` represent the same numeric value, by
 `CL:=`.
@@ -150,7 +150,7 @@ default (`T T`) methods which are implemented in terms of `LESSP`.
 
 .Methods
 
-* `NUMBER NUMBER`
+* `REAL REAL`
 +
 Returns true if the numeric value of `A` is less than the numeric
 value of `B`, by `CL:<`.
@@ -174,7 +174,7 @@ Returns true if object `A` is less than or equal to object `B`.
 
 .Methods
 
-* `NUMBER NUMBER`
+* `REAL REAL`
 +
 Returns true if the numeric value of `A` is less than or equal to
 the numeric value of `B`, by `+CL:<=+`.
@@ -208,7 +208,7 @@ Returns true if object `A` is greater than object `B`.
 
 .Methods
 
-* `NUMBER NUMBER`
+* `REAL REAL`
 +
 Returns true if the numeric value of `A` is greater than the
 numeric value of `B`, by `CL:>`.
@@ -241,7 +241,7 @@ Returns true if object `A` is greater than or equal to object `B`.
 
 .Methods
 
-* `NUMBER NUMBER`
+* `REAL REAL`
 +
 Returns true if the numeric value of `A` is greater than or equal
 to the numeric value of `B`, by `CL:>=`.

--- a/doc/comparison.adoc
+++ b/doc/comparison.adoc
@@ -29,7 +29,7 @@ Generic Function: `EQUALP A B`
 Returns true if object `A` is equal to object `B`.
 
 .Methods
-* `REAL REAL`
+* `NUMBER NUMBER`
 +
 Returns true if `A` and `B` represent the same numeric value, by
 `CL:=`.

--- a/src/arithmetic/arithmetic.lisp
+++ b/src/arithmetic/arithmetic.lisp
@@ -134,10 +134,10 @@
   (cl:1- a))
 
 
-(defmethod minusp ((a number))
+(defmethod minusp ((a real))
   (cl:minusp a))
 
-(defmethod plusp ((a number))
+(defmethod plusp ((a real))
   (cl:plusp a))
 
 (defmethod zerop ((a number))
@@ -150,38 +150,38 @@
   (cl:abs a))
 
 
-(defmethod evenp ((a number))
+(defmethod evenp ((a integer))
   (cl:evenp a))
 
-(defmethod oddp ((a number))
+(defmethod oddp ((a integer))
   (cl:oddp a))
 
 
-(defmethod floor ((n number) &optional (d nil d-sp))
+(defmethod floor ((n real) &optional (d nil d-sp))
   (if d-sp
       (cl:floor n d)
       (cl:floor n)))
 
-(defmethod ceiling ((n number) &optional (d nil d-sp))
+(defmethod ceiling ((n real) &optional (d nil d-sp))
   (if d-sp
       (cl:ceiling n d)
       (cl:ceiling n)))
 
-(defmethod truncate ((n number) &optional (d nil d-sp))
+(defmethod truncate ((n real) &optional (d nil d-sp))
   (if d-sp
       (cl:truncate n d)
       (cl:truncate n)))
 
-(defmethod round ((n number) &optional (d nil d-sp))
+(defmethod round ((n real) &optional (d nil d-sp))
   (if d-sp
       (cl:round n d)
       (cl:round n)))
 
 
-(defmethod mod ((n number) (d number))
+(defmethod mod ((n real) (d real))
   (cl:mod n d))
 
-(defmethod rem ((n number) (d number))
+(defmethod rem ((n real) (d real))
   (cl:rem n d))
 
 

--- a/src/comparison/comparison.lisp
+++ b/src/comparison/comparison.lisp
@@ -76,9 +76,9 @@
   (not (lessp a b)))
 
 
-;; Numbers
+;; Real Numbers
 
-(defmethod compare ((a number) (b number))
+(defmethod compare ((a real) (b real))
   (let ((diff (cl:- a b)))
     (cond
       ((cl:zerop diff)
@@ -90,16 +90,16 @@
       ((cl:minusp diff)
        :less))))
 
-(defmethod lessp ((a number) (b number))
+(defmethod lessp ((a real) (b real))
   (cl:< a b))
 
-(defmethod greaterp ((a number) (b number))
+(defmethod greaterp ((a real) (b real))
   (cl:> a b))
 
-(defmethod less-equal-p ((a number) (b number))
+(defmethod less-equal-p ((a real) (b real))
   (cl:<= a b))
 
-(defmethod greater-equal-p ((a number) (b number))
+(defmethod greater-equal-p ((a real) (b real))
   (cl:>= a b))
 
 


### PR DESCRIPTION
Thank you for the great project!
I am excited to see the new better common-lisp standard.

This pull request fixes the mathematical impossibility that we cannot inspect the property of complex numbers.

As you know, the CL's NUMBER class contains the complex number class which cannot run on the comparison and also run no such mathematical operation such as `mod`. Further, unfortunately, we cannot check the rational number is even or not in CL.

Thus, this pull request changes the class of arguments of a few methods. I hope it would help your project.

Cheers.
