### PR TITLE
Added (setf first) for list, array and vector

### DIFF
--- a/src/container/cl-containers.lisp
+++ b/src/container/cl-containers.lisp
@@ -109,12 +109,20 @@
 (defmethod first ((list list))
   (cl:first list))
 
+(defmethod (setf first) (value (list list))
+  (setf (cl:first list) value))
+
 (defmethod first ((vec vector))
   (aref vec 0))
+
+(defmethod (setf first) (value (vec vector))
+  (setf (aref vec 0) value))
 
 (defmethod first ((array array))
   (row-major-aref array 0))
 
+(defmethod (setf first) (value (array array))
+  (setf (row-major-aref array 0) value))
 
 ;;;; Last
 

--- a/src/container/container.lisp
+++ b/src/container/container.lisp
@@ -39,6 +39,10 @@
   (:documentation
    "Returns the first element of SEQUENCE."))
 
+(defgeneric (setf first) (sequence)
+  (:documentation
+   "Sets the first element of SEQUENCE."))
+
 (defgeneric last (sequence &optional n)
   (:documentation
    "Returns the N'th (default 0) element from the last element of

--- a/test/sequences.lisp
+++ b/test/sequences.lisp
@@ -369,6 +369,21 @@
     (1 (first #2A((1 2) (3 4))))
     ('x (first (list-wrap 'x 'y 'z)))))
 
+(test setf-first
+      "Test generic (SETF FIRST) function"
+
+  (alet (list 1 2 3 4)
+    (is (= 'x (setf (first it) 'x)))
+    (is (= '(x 2 3 4) it)))
+
+  (alet (vector 1 2 3 4)
+    (is (= 'x (setf (first it) 'x)))
+    (is (= #(x 2 3 4) it)))
+
+  (alet (make-array '(2 2) :initial-contents '((1 2) (3 4)))
+    (is (= 'a (setf (first it) 'a)))
+    (is (= #2A((a 2) (3 4)) it))))
+
 (test last
   "Test generic LAST function"
 


### PR DESCRIPTION
Hello, this is my first pull request for an open source library. 
I recently switched to common lisp and am still learning the idiomatic ways.
When switching from common-lisp to generic-cl sbcl informed me that first is not setf-able anymore. Is this the wanted behaviour?